### PR TITLE
add generic tab block, styling for wrappers and humidification

### DIFF
--- a/cigars-for-beginners/blocks/tabs/tabs.css
+++ b/cigars-for-beginners/blocks/tabs/tabs.css
@@ -1,0 +1,58 @@
+.tabs .tabs-list {
+  display: flex;
+  gap: 0.5ch;
+  max-width: 100%;
+  font-size: var(--body-font-size-xs);
+  overflow-x: auto;
+}
+
+@media (width >= 600px) {
+  .tabs .tabs-list {
+    font-size: var(--body-font-size-s);
+  }
+}
+
+@media (width >= 900px) {
+  .tabs .tabs-list {
+    font-size: var(--body-font-size-m);
+  }
+}
+
+.tabs .tabs-list button {
+  flex: 0 0 max-content;
+  margin: 0;
+  border: 1px solid #dadada;
+  border-radius: 0;
+  padding: 0.5em;
+  background-color: var(--light-color);
+  color: initial;
+  font-weight: bold;
+  line-height: unset;
+  text-align: initial;
+  text-overflow: unset;
+  overflow: unset;
+  white-space: unset;
+  transition: background-color 0.2s;
+}
+
+.tabs .tabs-list button p {
+  margin: 0;
+}
+
+
+.tabs .tabs-list button[aria-selected='true'] {
+  border-bottom: 1px solid var(--background-color);
+  background-color: var(--background-color);
+  cursor: initial;
+}
+
+.tabs .tabs-panel {
+  margin-top: -1px;
+  padding: 24px;
+  border: 1px solid #dadada;
+  overflow: auto;
+}
+
+.tabs .tabs-panel[aria-hidden='true'] {
+  display: none;
+}

--- a/cigars-for-beginners/blocks/tabs/tabs.js
+++ b/cigars-for-beginners/blocks/tabs/tabs.js
@@ -1,0 +1,47 @@
+// eslint-disable-next-line import/no-unresolved
+import { toClassName } from '../../scripts/aem.js';
+
+export default async function decorate(block) {
+  // build tablist
+  const tablist = document.createElement('div');
+  tablist.className = 'tabs-list';
+  tablist.setAttribute('role', 'tablist');
+
+  // decorate tabs and tabpanels
+  const tabs = [...block.children].map((child) => child.firstElementChild);
+  tabs.forEach((tab, i) => {
+    const id = toClassName(tab.textContent);
+
+    // decorate tabpanel
+    const tabpanel = block.children[i];
+    tabpanel.className = 'tabs-panel';
+    tabpanel.id = `tabpanel-${id}`;
+    tabpanel.setAttribute('aria-hidden', !!i);
+    tabpanel.setAttribute('aria-labelledby', `tab-${id}`);
+    tabpanel.setAttribute('role', 'tabpanel');
+
+    // build tab button
+    const button = document.createElement('button');
+    button.className = 'tabs-tab';
+    button.id = `tab-${id}`;
+    button.innerHTML = tab.innerHTML;
+    button.setAttribute('aria-controls', `tabpanel-${id}`);
+    button.setAttribute('aria-selected', !i);
+    button.setAttribute('role', 'tab');
+    button.setAttribute('type', 'button');
+    button.addEventListener('click', () => {
+      block.querySelectorAll('[role=tabpanel]').forEach((panel) => {
+        panel.setAttribute('aria-hidden', true);
+      });
+      tablist.querySelectorAll('button').forEach((btn) => {
+        btn.setAttribute('aria-selected', false);
+      });
+      tabpanel.setAttribute('aria-hidden', false);
+      button.setAttribute('aria-selected', true);
+    });
+    tablist.append(button);
+    tab.remove();
+  });
+
+  block.prepend(tablist);
+}

--- a/cigars-for-beginners/styles/styles.css
+++ b/cigars-for-beginners/styles/styles.css
@@ -375,6 +375,14 @@ main .section:empty {
   overflow: visible;
 }
 
+.wrapper-tabs .tabs .tabs-panel img {
+  border-radius: 50%;
+}
+
+.cigar-pairing .columns > div > div p:first-child img {
+  max-width: 152px;
+}
+
 .humi-tabs .tabs .tabs-list img:hover {
   transform: scale(1.1);
 }
@@ -385,10 +393,6 @@ main .section:empty {
   box-shadow:
       0 0 0 7px #d8d8d8,  /* First outline: 7px, blue */
       0 0 0 8px #333; /* Second outline: 1px, green */
-}
-
-.wrapper-tabs .tabs .tabs-panel img {
-  border-radius: 50%;
 }
 
 .compare-list .columns > div {
@@ -417,10 +421,6 @@ main .section:empty {
 
 .cigar-pairing .columns > div > div {
   overflow: hidden;
-}
-
-.cigar-pairing .columns > div > div p:first-child img {
-  max-width: 152px;
 }
 
 .numbered-comparison p {

--- a/cigars-for-beginners/styles/styles.css
+++ b/cigars-for-beginners/styles/styles.css
@@ -520,6 +520,37 @@ main .section.cigar-terminology {
   margin-left: 225px;
 }
 
+@media (max-width: 500px) {
+  .wrapper-tabs .tabs .tabs-list p:nth-child(2) {
+    display: none;
+  }
+
+  .wrapper-tabs .tabs .tabs-panel p {
+    float: none;
+    text-align: center;
+  }
+
+  .wrapper-tabs .tabs .tabs-panel ul {
+    margin: 0 auto;
+  }
+
+  .wrapper-tabs .tabs .tabs-panel h4 {
+    margin: 0 auto;
+  }
+
+  .wrapper-tabs .tabs .tabs-panel img {
+    float: none;
+    width: 50%;
+    max-width: 150px;
+    display: block;
+    margin: 0 auto 20px auto;
+  }
+
+  .wrapper-tabs .tabs .tabs-list button {
+    padding-bottom: 10px;
+  }
+}
+
 .humi-tabs .tabs .tabs-list {
   display: inline;
   max-width: 100%;

--- a/cigars-for-beginners/styles/styles.css
+++ b/cigars-for-beginners/styles/styles.css
@@ -443,3 +443,114 @@ main .section.cigar-terminology {
 .infused-cigars .default-content-wrapper {
   text-align: center;
 }
+
+.wrapper-tabs .default-content-wrapper {
+  text-align: center;
+}
+
+.wrapper-tabs .tabs .tabs-list {
+  display: inline;
+  max-width: 100%;
+  font-size: var(--body-font-size-xs);
+  overflow-x: auto;
+}
+
+.wrapper-tabs .tabs .tabs-list button {
+  display: inline-grid;
+  margin: 0;
+  border: 0;
+  border-radius: 0;
+  padding: 0 0 50px 0;
+  background-color: transparent;
+  color: initial;
+  font-weight: bold;
+  line-height: unset;
+  text-overflow: unset;
+  overflow: unset;
+  white-space: unset;
+  transition: background-color 0.2s;
+  text-align: center;
+  width: 14.285714%;
+}
+
+.wrapper-tabs .tabs .tabs-list button[aria-selected='true'] {
+  border-bottom: 0;
+  background-color: transparent;
+  cursor: initial;
+}
+
+.wrapper-tabs .tabs .tabs-list button[aria-selected='true'] img {
+  position: relative;
+  z-index: 35;
+  box-shadow:
+      0 0 0 7px #d8d8d8,  /* First outline: 7px, blue */
+      0 0 0 8px #333; /* Second outline: 1px, green */
+}
+
+.wrapper-tabs .tabs .tabs-panel {
+  margin-top: -1px;
+  padding: 0;
+  border: 0;
+  overflow: auto;
+}
+
+.wrapper-tabs .tabs .tabs-panel p {
+  float: left;
+}
+
+.wrapper-tabs .tabs .tabs-panel ul {
+  margin-left: 225px;
+}
+
+.wrapper-tabs .tabs .tabs-panel h4 {
+  margin-left: 225px;
+}
+
+.wrapper-tabs .tabs .tabs-panel img {
+  border-radius: 50%;
+}
+
+.wrapper-tabs .default-content-wrapper {
+  text-align: center;
+}
+
+.humi-tabs .tabs .tabs-list {
+  display: inline;
+  max-width: 100%;
+  font-size: var(--body-font-size-xs);
+  overflow-x: auto;
+}
+
+.humi-tabs .tabs .tabs-list button {
+  border: 0;
+  background-color: transparent;
+  width: 20%;
+  text-align: center;
+  position: relative;
+  overflow: hidden;
+  padding-top: 20px;
+  padding-bottom: 40px;
+}
+
+.humi-tabs .tabs .tabs-list img {
+  height: 120px;
+  margin-bottom: 8px;
+  overflow: visible;
+}
+
+.humi-tabs .tabs .tabs-list img:hover {
+  transform: scale(1.1);
+}
+
+.humi-tabs .tabs .tabs-list button[aria-selected='true'] {
+  border-bottom: 0;
+  cursor: initial;
+  background: url("/cigars-for-beginners/images/media_14bd13a9db54810d16ac3a87e78aeacd08d800a20.png");
+  background-position: center bottom;
+  background-repeat: no-repeat;
+}
+
+.humi-tabs .tabs .tabs-panel {
+  background: white;
+}
+

--- a/cigars-for-beginners/styles/styles.css
+++ b/cigars-for-beginners/styles/styles.css
@@ -369,6 +369,28 @@ main .section:empty {
   max-height: 330px;
 }
 
+.humi-tabs .tabs .tabs-list img {
+  height: 120px;
+  margin-bottom: 8px;
+  overflow: visible;
+}
+
+.humi-tabs .tabs .tabs-list img:hover {
+  transform: scale(1.1);
+}
+
+.wrapper-tabs .tabs .tabs-list button[aria-selected='true'] img {
+  position: relative;
+  z-index: 35;
+  box-shadow:
+      0 0 0 7px #d8d8d8,  /* First outline: 7px, blue */
+      0 0 0 8px #333; /* Second outline: 1px, green */
+}
+
+.wrapper-tabs .tabs .tabs-panel img {
+  border-radius: 50%;
+}
+
 .compare-list .columns > div {
   align-items: start;
 }
@@ -460,7 +482,7 @@ main .section.cigar-terminology {
   margin: 0;
   border: 0;
   border-radius: 0;
-  padding: 0 0 50px 0;
+  padding: 0 0 50px;
   background-color: transparent;
   color: initial;
   font-weight: bold;
@@ -470,21 +492,13 @@ main .section.cigar-terminology {
   white-space: unset;
   transition: background-color 0.2s;
   text-align: center;
-  width: 14.285714%;
+  width: 14.2857%;
 }
 
 .wrapper-tabs .tabs .tabs-list button[aria-selected='true'] {
   border-bottom: 0;
   background-color: transparent;
   cursor: initial;
-}
-
-.wrapper-tabs .tabs .tabs-list button[aria-selected='true'] img {
-  position: relative;
-  z-index: 35;
-  box-shadow:
-      0 0 0 7px #d8d8d8,  /* First outline: 7px, blue */
-      0 0 0 8px #333; /* Second outline: 1px, green */
 }
 
 .wrapper-tabs .tabs .tabs-panel {
@@ -506,14 +520,6 @@ main .section.cigar-terminology {
   margin-left: 225px;
 }
 
-.wrapper-tabs .tabs .tabs-panel img {
-  border-radius: 50%;
-}
-
-.wrapper-tabs .default-content-wrapper {
-  text-align: center;
-}
-
 .humi-tabs .tabs .tabs-list {
   display: inline;
   max-width: 100%;
@@ -530,16 +536,6 @@ main .section.cigar-terminology {
   overflow: hidden;
   padding-top: 20px;
   padding-bottom: 40px;
-}
-
-.humi-tabs .tabs .tabs-list img {
-  height: 120px;
-  margin-bottom: 8px;
-  overflow: visible;
-}
-
-.humi-tabs .tabs .tabs-list img:hover {
-  transform: scale(1.1);
 }
 
 .humi-tabs .tabs .tabs-list button[aria-selected='true'] {

--- a/cigars-for-beginners/styles/styles.css
+++ b/cigars-for-beginners/styles/styles.css
@@ -348,6 +348,10 @@ main .section:empty {
   text-align: center;
 }
 
+.wrapper-tabs .default-content-wrapper {
+  text-align: center;
+}
+
 .section.center-text .default-content-wrapper {
   text-align: center;
 }
@@ -470,10 +474,6 @@ main .section.cigar-terminology {
   margin: 2em auto 3em;
 }
 
-.wrapper-tabs .default-content-wrapper {
-  text-align: center;
-}
-
 .wrapper-tabs .tabs .tabs-list {
   display: inline;
   max-width: 100%;
@@ -525,15 +525,15 @@ main .section.cigar-terminology {
 }
 
 @media (max-width: 500px) {
-  .wrapper-tabs .tabs .tabs-list p:nth-child(2) {
-    display: none;
-  }
-
   .wrapper-tabs .tabs .tabs-panel p {
     float: none;
     text-align: center;
   }
 
+  .wrapper-tabs .tabs .tabs-list p:nth-child(2) {
+    display: none;
+  }
+  
   .wrapper-tabs .tabs .tabs-panel ul {
     margin: 0 auto;
   }
@@ -547,7 +547,7 @@ main .section.cigar-terminology {
     width: 50%;
     max-width: 150px;
     display: block;
-    margin: 0 auto 20px auto;
+    margin: 0 auto 20px;
   }
 
   .wrapper-tabs .tabs .tabs-list button {


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #42

Test URLs:
- Before: https://main--cigars-for-beginners--famous-smoke.hlx.live/cigars-for-beginners
- After: https://42-create-tabs-block--cigars-for-beginners--famous-smoke.hlx.page/cigars-for-beginners

Tabs are located on these pages:
/cigars-for-beginners/keeping-your-cigars-fresh
/cigars-for-beginners/develop-your-collection

Added generic tabs block and styled each section

