### PR TITLE
Change GTM ID

### DIFF
--- a/cigars-for-beginners/scripts/delayed.js
+++ b/cigars-for-beginners/scripts/delayed.js
@@ -19,7 +19,7 @@ function onGALoad() {
     dataLayer.push(arguments);
   }
   gtag('js', new Date());
-  gtag('config', 'GT-NFRPRDJP');
+  gtag('config', 'G-S1GMVHJEKZ');
   gtag('set', 'linker', { domains: ['www.famous-smoke.com'] });
 }
 
@@ -27,7 +27,7 @@ function loadGoogleAnalytics() {
   // Load the Google Analytics library
   const tag = document.createElement('script');
   tag.async = true;
-  tag.src = 'https://www.googletagmanager.com/gtag/js?id=GT-NFRPRDJP';
+  tag.src = 'https://www.googletagmanager.com/gtag/js?id=G-S1GMVHJEKZ';
   document.head.appendChild(tag);
   // Configuration script
   tag.onload = onGALoad;


### PR DESCRIPTION
Changes GTM ID to match Famous

Fix #45

Test URLs:
- Before: https://main--cigars-for-beginners--famous-smoke.hlx.live/cigars-for-beginners
- After: https://45-change-gtm-id--cigars-for-beginners--famous-smoke.hlx.page/cigars-for-beginners
