### PR TITLE
Update carousel block to latest code from AEM block collection

### DIFF
--- a/cigars-for-beginners/blocks/carousel/carousel.css
+++ b/cigars-for-beginners/blocks/carousel/carousel.css
@@ -25,19 +25,11 @@
   scroll-snap-align: start;
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
-  justify-content: center;
+  align-items: center;
+  justify-content: flex-end;
   position: relative;
   width: 100%;
-  min-height: min(50vw, calc(100dvh - var(--header-height)));
-}
-
-.carousel .carousel-slide:has(.carousel-slide-content[data-align='center']) {
-  align-items: center;
-}
-
-.carousel .carousel-slide:has(.carousel-slide-content[data-align='right']) {
-  align-items: flex-end;
+  min-height: min(40rem, calc(100svh - var(--nav-height)));
 }
 
 .carousel .carousel-slide .carousel-slide-image picture {
@@ -53,45 +45,71 @@
 
 .carousel .carousel-slide .carousel-slide-content {
   z-index: 1;
-  margin: 68px;
-  padding: 16px;
+  padding: 1rem;
+  margin: 1.5rem 3rem;
   color: white;
-  background-color: rgba(19 19 19 / 75%);
+  background-color: rgba(0 0 0 / 70%);
   position: relative;
   width: var(--slide-content-width, auto);
+  align-items: center;
+  overflow: hidden; /* Initially hide overflow */
+  max-height: 10rem; /* Set a max height for the content */
+  transition: max-height 0.3s ease; /* Smooth transition for expanding */
+}
+
+.carousel .carousel-slide .carousel-slide-content.show-more {
+  overflow-y: auto; /* Enable vertical scrolling when expanded */
+  max-height: 30rem; /* Set a max height for the expanded content */
+}
+
+.hidden-text {
+  display: none;
+}
+
+.show-more .hidden-text {
+  display: inline;
 }
 
 .carousel .carousel-slide-indicators {
   display: flex;
-  flex-wrap: wrap;
   justify-content: center;
-  gap: 6px 12px;
-  padding: 12px;
-  line-height: 0;
+  gap: 0.5rem;
 }
 
 .carousel .carousel-slide-indicator button {
-  width: 24px;
-  height: 24px;
-  margin: 0;
+  width: 1rem;
+  height: 1rem;
   padding: 0;
-  border-radius: 50%;
-  background-color: #dadada;
-  transition: background-color 0.2s;
+  border-radius: 1rem;
+  background-color: rgba(0 0 0 / 25%);
 }
 
 .carousel .carousel-slide-indicator button:disabled,
 .carousel .carousel-slide-indicator button:hover,
 .carousel .carousel-slide-indicator button:focus-visible {
-  background-color: var(--text-color);
+  background-color: rgba(0 0 0 / 80%);
+}
+
+.carousel .carousel-slide-indicator span,
+.carousel .carousel-navigation-buttons span {
+  border: 0;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+  white-space: nowrap;
 }
 
 .carousel .carousel-navigation-buttons {
   position: absolute;
   top: 50%;
   transform: translateY(-50%);
-  left: 12px;
-  right: 12px;
+  left: 0.5rem;
+  right: 0.5rem;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -100,53 +118,67 @@
 
 /* stylelint-disable-next-line no-descending-specificity */
 .carousel .carousel-navigation-buttons button {
-  position: relative;
-  width: 44px;
-  height: 44px;
+  border-radius: 8px;
   margin: 0;
-  border-radius: 50%;
   padding: 0;
-  background-color: rgba(19 19 19 / 25%);
-  transition: background-color 0.2s;
+  width: 2rem;
+  height: 2rem;
+  position: relative;
+  background-color: rgba(0 0 0 / 25%);
 }
 
 .carousel .carousel-navigation-buttons button:hover,
 .carousel .carousel-navigation-buttons button:focus-visible {
-  background-color: rgba(19 19 19 / 75%);
+  background-color: rgba(0 0 0 / 80%);
 }
 
 .carousel .carousel-navigation-buttons button::after {
   display: block;
   content: '';
-  border: 2px solid;
+  border: 3px white solid;
   border-bottom: 0;
   border-left: 0;
-  height: 12px;
-  width: 12px;
+  height: 0.75rem;
+  width: 0.75rem;
   position: absolute;
   top: 50%;
-  left: calc(50% + 2px);
+  left: calc(50% + 3px);
   transform: translate(-50%, -50%) rotate(-135deg);
 }
 
 .carousel .carousel-navigation-buttons button.slide-next::after {
   transform: translate(-50%, -50%) rotate(45deg);
-  left: calc(50% - 2px);
+  left: calc(50% - 3px);
+}
+
+.carousel-slide h4,
+.carousel-slide p {
+  margin-top: 0;
+}
+
+.carousel-slide a {
+  color: white;
 }
 
 @media (width >= 600px) {
   .carousel .carousel-navigation-buttons {
-    left: 24px;
-    right: 24px;
+    left: 1rem;
+    right: 1rem;
+  }
+
+  .carousel .carousel-navigation-buttons button {
+    width: 3rem;
+    height: 3rem;
+  }
+
+  .carousel .carousel-navigation-buttons button::after {
+    width: 1rem;
+    height: 1rem;
   }
 
   .carousel .carousel-slide .carousel-slide-content {
-    --slide-content-width: calc((100% - 184px) / 2);
+    --slide-content-width: 75%;
 
-    margin: 92px;
-  }
-
-  .carousel .carousel-slide .carousel-slide-content[data-align='justify'] {
-    --slide-content-width: auto;
+    margin: 2.5rem 5rem;
   }
 }

--- a/cigars-for-beginners/blocks/carousel/carousel.css
+++ b/cigars-for-beginners/blocks/carousel/carousel.css
@@ -25,11 +25,19 @@
   scroll-snap-align: start;
   display: flex;
   flex-direction: column;
-  align-items: center;
-  justify-content: flex-end;
+  align-items: flex-start;
+  justify-content: center;
   position: relative;
   width: 100%;
-  min-height: min(40rem, calc(100svh - var(--nav-height)));
+  min-height: min(50vw, calc(100dvh - var(--header-height)));
+}
+
+.carousel .carousel-slide:has(.carousel-slide-content[data-align='center']) {
+  align-items: center;
+}
+
+.carousel .carousel-slide:has(.carousel-slide-content[data-align='right']) {
+  align-items: flex-end;
 }
 
 .carousel .carousel-slide .carousel-slide-image picture {
@@ -45,71 +53,45 @@
 
 .carousel .carousel-slide .carousel-slide-content {
   z-index: 1;
-  padding: 1rem;
-  margin: 1.5rem 3rem;
+  margin: 68px;
+  padding: 16px;
   color: white;
-  background-color: rgba(0 0 0 / 70%);
+  background-color: rgba(19 19 19 / 75%);
   position: relative;
   width: var(--slide-content-width, auto);
-  align-items: center;
-  overflow: hidden; /* Initially hide overflow */
-  max-height: 10rem; /* Set a max height for the content */
-  transition: max-height 0.3s ease; /* Smooth transition for expanding */
-}
-
-.carousel .carousel-slide .carousel-slide-content.show-more {
-  overflow-y: auto; /* Enable vertical scrolling when expanded */
-  max-height: 30rem; /* Set a max height for the expanded content */
-}
-
-.hidden-text {
-  display: none;
-}
-
-.show-more .hidden-text {
-  display: inline;
 }
 
 .carousel .carousel-slide-indicators {
   display: flex;
+  flex-wrap: wrap;
   justify-content: center;
-  gap: 0.5rem;
+  gap: 6px 12px;
+  padding: 12px;
+  line-height: 0;
 }
 
 .carousel .carousel-slide-indicator button {
-  width: 1rem;
-  height: 1rem;
+  width: 24px;
+  height: 24px;
+  margin: 0;
   padding: 0;
-  border-radius: 1rem;
-  background-color: rgba(0 0 0 / 25%);
+  border-radius: 50%;
+  background-color: #dadada;
+  transition: background-color 0.2s;
 }
 
 .carousel .carousel-slide-indicator button:disabled,
 .carousel .carousel-slide-indicator button:hover,
 .carousel .carousel-slide-indicator button:focus-visible {
-  background-color: rgba(0 0 0 / 80%);
-}
-
-.carousel .carousel-slide-indicator span,
-.carousel .carousel-navigation-buttons span {
-  border: 0;
-  clip: rect(0 0 0 0);
-  clip-path: inset(50%);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  width: 1px;
-  white-space: nowrap;
+  background-color: var(--text-color);
 }
 
 .carousel .carousel-navigation-buttons {
   position: absolute;
   top: 50%;
   transform: translateY(-50%);
-  left: 0.5rem;
-  right: 0.5rem;
+  left: 12px;
+  right: 12px;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -118,67 +100,53 @@
 
 /* stylelint-disable-next-line no-descending-specificity */
 .carousel .carousel-navigation-buttons button {
-  border-radius: 8px;
-  margin: 0;
-  padding: 0;
-  width: 2rem;
-  height: 2rem;
   position: relative;
-  background-color: rgba(0 0 0 / 25%);
+  width: 44px;
+  height: 44px;
+  margin: 0;
+  border-radius: 50%;
+  padding: 0;
+  background-color: rgba(19 19 19 / 25%);
+  transition: background-color 0.2s;
 }
 
 .carousel .carousel-navigation-buttons button:hover,
 .carousel .carousel-navigation-buttons button:focus-visible {
-  background-color: rgba(0 0 0 / 80%);
+  background-color: rgba(19 19 19 / 75%);
 }
 
 .carousel .carousel-navigation-buttons button::after {
   display: block;
   content: '';
-  border: 3px white solid;
+  border: 2px solid;
   border-bottom: 0;
   border-left: 0;
-  height: 0.75rem;
-  width: 0.75rem;
+  height: 12px;
+  width: 12px;
   position: absolute;
   top: 50%;
-  left: calc(50% + 3px);
+  left: calc(50% + 2px);
   transform: translate(-50%, -50%) rotate(-135deg);
 }
 
 .carousel .carousel-navigation-buttons button.slide-next::after {
   transform: translate(-50%, -50%) rotate(45deg);
-  left: calc(50% - 3px);
-}
-
-.carousel-slide h4,
-.carousel-slide p {
-  margin-top: 0;
-}
-
-.carousel-slide a {
-  color: white;
+  left: calc(50% - 2px);
 }
 
 @media (width >= 600px) {
   .carousel .carousel-navigation-buttons {
-    left: 1rem;
-    right: 1rem;
-  }
-
-  .carousel .carousel-navigation-buttons button {
-    width: 3rem;
-    height: 3rem;
-  }
-
-  .carousel .carousel-navigation-buttons button::after {
-    width: 1rem;
-    height: 1rem;
+    left: 24px;
+    right: 24px;
   }
 
   .carousel .carousel-slide .carousel-slide-content {
-    --slide-content-width: 75%;
+    --slide-content-width: calc((100% - 184px) / 2);
 
-    margin: 2.5rem 5rem;
+    margin: 92px;
+  }
+
+  .carousel .carousel-slide .carousel-slide-content[data-align='justify'] {
+    --slide-content-width: auto;
   }
 }

--- a/cigars-for-beginners/blocks/carousel/carousel.js
+++ b/cigars-for-beginners/blocks/carousel/carousel.js
@@ -1,8 +1,5 @@
 import { fetchPlaceholders } from '../../scripts/aem.js';
 
-const NUM_SHOW_HIDE_WORDS_MOBILE = 12;
-const NUM_SHOW_HIDE_WORDS_DESKTOP = 33;
-
 function updateActiveSlide(slide) {
   const block = slide.closest('.carousel');
   const slideIndex = parseInt(slide.dataset.slideIndex, 10);
@@ -63,39 +60,14 @@ function bindEvents(block) {
     showSlide(block, parseInt(block.dataset.activeSlide, 10) + 1);
   });
 
-  const slideObserver = new IntersectionObserver(
-    (entries) => {
-      entries.forEach((entry) => {
-        if (entry.isIntersecting) updateActiveSlide(entry.target);
-      });
-    },
-    // eslint-disable-next-line comma-dangle
-    { threshold: 0.5 }
-  );
-
+  const slideObserver = new IntersectionObserver((entries) => {
+    entries.forEach((entry) => {
+      if (entry.isIntersecting) updateActiveSlide(entry.target);
+    });
+  }, { threshold: 0.5 });
   block.querySelectorAll('.carousel-slide').forEach((slide) => {
     slideObserver.observe(slide);
   });
-}
-
-// eslint-disable-next-line max-len
-const numShowHideWords = window.innerWidth < 600 ? NUM_SHOW_HIDE_WORDS_MOBILE : NUM_SHOW_HIDE_WORDS_DESKTOP;
-
-// Function to toggle text visibility
-function toggleText(span, link, words, container) {
-  if (span.classList.contains('hidden-text')) {
-    span.classList.remove('hidden-text');
-    span.classList.add('show-more');
-    link.textContent = ' Read Less';
-    span.previousSibling.textContent = words.join(' ');
-    container.classList.add('show-more'); // Add this line to allow scrolling
-  } else {
-    span.classList.add('hidden-text');
-    span.classList.remove('show-more');
-    link.textContent = ' ...Read More';
-    span.previousSibling.textContent = `${words.slice(0, numShowHideWords).join(' ')}...`;
-    container.classList.remove('show-more'); // Add this line to disable scrolling
-  }
 }
 
 function createSlide(row, slideIndex, carouselId) {
@@ -105,37 +77,7 @@ function createSlide(row, slideIndex, carouselId) {
   slide.classList.add('carousel-slide');
 
   row.querySelectorAll(':scope > div').forEach((column, colIdx) => {
-    const carouselSlideClass = `carousel-slide-${colIdx === 0 ? 'image' : 'content'}`;
-    column.classList.add(carouselSlideClass);
-    if (carouselSlideClass === 'carousel-slide-content') {
-      const p = column.querySelector('p');
-      const pId = `p-carousel-${carouselId}-slide-${slideIndex}`;
-      p.id = pId;
-
-      // Split the text into words
-      const words = p.textContent.split(' ');
-      const visibleWords = words.slice(0, numShowHideWords).join(' ');
-      const hiddenWords = words.slice(numShowHideWords).join(' ');
-      p.textContent = `${visibleWords}...`;
-
-      // Add hidden words to span
-      const span = document.createElement('span');
-      span.className = 'hidden-text';
-      span.textContent = ` ${hiddenWords}`;
-      p.appendChild(span);
-
-      // Add read more/less link
-      const link = document.createElement('a');
-      link.href = '#';
-      link.onclick = () => {
-        toggleText(span, link, words, column);
-        return false;
-      };
-      link.textContent = '...Read More';
-
-      // Append the link after the paragraph
-      p.parentNode.insertBefore(link, p.nextSibling);
-    }
+    column.classList.add(`carousel-slide-${colIdx === 0 ? 'image' : 'content'}`);
     slide.append(column);
   });
 
@@ -193,7 +135,7 @@ export default async function decorate(block) {
       const indicator = document.createElement('li');
       indicator.classList.add('carousel-slide-indicator');
       indicator.dataset.targetSlide = idx;
-      indicator.innerHTML = `<button type="button"><span>${placeholders.showSlide || 'Show Slide'} ${idx + 1} ${placeholders.of || 'of'} ${rows.length}</span></button>`;
+      indicator.innerHTML = `<button type="button" aria-label="${placeholders.showSlide || 'Show Slide'} ${idx + 1} ${placeholders.of || 'of'} ${rows.length}"></button>`;
       slideIndicators.append(indicator);
     }
     row.remove();

--- a/cigars-for-beginners/styles/styles.css
+++ b/cigars-for-beginners/styles/styles.css
@@ -171,7 +171,6 @@ button {
   cursor: pointer;
   color: var(--background-color);
   background-color: var(--button-color);
-  white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
   transition: background .2s;
@@ -533,7 +532,7 @@ main .section.cigar-terminology {
   .wrapper-tabs .tabs .tabs-list p:nth-child(2) {
     display: none;
   }
-  
+
   .wrapper-tabs .tabs .tabs-panel ul {
     margin: 0 auto;
   }


### PR DESCRIPTION
Updates carousel.js and carousel.css to the latest changes from the AEM block collection:

- https://github.com/adobe/aem-block-collection/blob/main/blocks/carousel/carousel.js
- https://github.com/adobe/aem-block-collection/blob/main/blocks/carousel/carousel.css

These changes removed the read more/less links. I verified the existing carousels still display correctly, I did have to remove the background-color they added for the slider dots.

Fix #48 

Test URLs:
- Before: https://main--cigars-for-beginners--famous-smoke.hlx.live/cigars-for-beginners/develop-your-taste
- After: https://48-info-overlay-block--cigars-for-beginners--famous-smoke.hlx.page/cigars-for-beginners/develop-your-taste
