### PR TITLE
Display hero behind nav, remove video summary embed title

### DIFF
--- a/cigars-for-beginners/blocks/hero/hero.css
+++ b/cigars-for-beginners/blocks/hero/hero.css
@@ -11,6 +11,7 @@ main .hero-container {
   position: relative;
   padding: 32px;
   min-height: 300px;
+  margin-top: calc(0px - var(--nav-height));
 }
 
 .hero h1 {
@@ -19,6 +20,13 @@ main .hero-container {
   margin-right: auto;
   color: white;
   font-size: var(--heading-font-size-xxl);
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  left: 0;
+  right: 0;
+  padding: 0 0.5em;
+  text-shadow: 1px 1px 2px #333;
 }
 
 .hero picture {

--- a/cigars-for-beginners/blocks/hero/hero.css
+++ b/cigars-for-beginners/blocks/hero/hero.css
@@ -7,30 +7,24 @@ main .hero-container {
   max-width: none;
 }
 
+main .hero-container + .section {
+  padding-top: 0;
+}
+
 .hero {
   position: relative;
-  padding: 32px;
+  padding: 32px 0;
   min-height: 300px;
   margin-top: calc(0px - var(--nav-height));
 }
 
 .hero h1 {
   max-width: var(--content-width);
-  margin-left: auto;
-  margin-right: auto;
-  color: white;
-  font-size: var(--heading-font-size-xxl);
-  position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
-  left: 0;
-  right: 0;
-  padding: 0 0.5em;
-  text-shadow: 1px 1px 2px #333;
+  margin: 32px auto;
+  padding: 0 32px;
 }
 
 .hero picture {
-  position: absolute;
   z-index: -1;
   inset: 0;
   object-fit: cover;
@@ -41,4 +35,11 @@ main .hero-container {
   object-fit: cover;
   width: 100%;
   height: 100%;
+  max-height: 500px;
+}
+
+@media (max-width: 768px) {
+  .hero img {
+    max-height: 300px;
+  }
 }

--- a/cigars-for-beginners/blocks/hero/hero.css
+++ b/cigars-for-beginners/blocks/hero/hero.css
@@ -13,15 +13,15 @@ main .hero-container + .section {
 
 .hero {
   position: relative;
-  padding: 32px 0;
+  padding: 0 0 32px;
   min-height: 300px;
-  margin-top: calc(0px - var(--nav-height));
 }
 
 .hero h1 {
   max-width: var(--content-width);
   margin: 32px auto;
   padding: 0 32px;
+  text-align: center;
 }
 
 .hero picture {
@@ -36,6 +36,10 @@ main .hero-container + .section {
   width: 100%;
   height: 100%;
   max-height: 500px;
+}
+
+.hero p {
+  margin: 0;
 }
 
 @media (max-width: 768px) {

--- a/cigars-for-beginners/blocks/video-summary/video-summary.css
+++ b/cigars-for-beginners/blocks/video-summary/video-summary.css
@@ -14,17 +14,6 @@
     cursor: pointer;
 }
 
-.video-summary .video-summary-embed-title {
-    position: absolute;
-    top: 0;
-    color: #fff;
-    margin: 0 auto;
-    padding: 0.5em;
-    text-shadow: 2px 2px black;
-    font-size: var(--body-font-size-m);
-    background: #00000075;
-}
-
 .video-summary .video-summary-embed-facade::after {
     content: url('/cigars-for-beginners/icons/play.png');
     position: absolute;
@@ -82,10 +71,4 @@
 .video-summary > div > div:last-child p.show {
     visibility: visible;
     max-height: 500px;
-}
-
-@media (max-width: 600px) {
-    .video-summary-embed-title {
-        font-size: 0.8em;
-    }
 }

--- a/cigars-for-beginners/blocks/video-summary/video-summary.js
+++ b/cigars-for-beginners/blocks/video-summary/video-summary.js
@@ -39,18 +39,14 @@ function getShowHide() {
 export default async function decorate(block) {
   const url = block.querySelector('a');
 
-  const title = block.querySelector('h3');
-  title.className = 'video-summary-embed-title';
-
   const img = block.querySelector('img');
   img.className = 'video-summary-embed';
 
-  const facadeWrap = title.parentElement;
+  const facadeWrap = img.parentElement;
   facadeWrap.className = 'video-summary-embed-facade';
   facadeWrap.addEventListener('click', () => {
     const embed = getEmbed(url.innerText);
     facadeWrap.replaceWith(embed);
-    title.remove();
   });
 
   url.remove();


### PR DESCRIPTION
Display the hero block behind the nav, vertically center the hero h1 text, add a slight text shadow to the hero h1 for better visibility, and remove the video summary embed title as discussed with Cory. 

Fix #54

Test URLs:
- Before: https://main--cigars-for-beginners--famous-smoke.hlx.live/cigars-for-beginners
- After: https://54-fix-hero-alignment--cigars-for-beginners--famous-smoke.hlx.page/cigars-for-beginners
